### PR TITLE
feat: canvas HiDPI, off-screen optimization, ball bounce, chip diff updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,14 @@
       <header>
         <h1>Roulette</h1>
         <div id="balance-display">Balance: <span id="balance">1000</span></div>
+        <button id="colorblind-toggle" aria-label="Toggle colorblind mode">CB</button>
+        <button id="new-game-btn">NEW GAME</button>
       </header>
 
       <main>
         <div id="wheel-container">
-          <canvas id="wheel-canvas" width="400" height="400"></canvas>
-          <div id="result-display" class="hidden"></div>
+          <canvas id="wheel-canvas" width="400" height="400" role="img" aria-label="Roulette wheel"></canvas>
+          <div id="result-display" class="hidden" aria-live="polite"></div>
         </div>
 
         <div id="controls">
@@ -25,14 +27,24 @@
           <div id="action-buttons">
             <button id="spin-btn" disabled>SPIN</button>
             <button id="clear-btn">CLEAR BETS</button>
+            <button id="repeat-btn" disabled>REPEAT</button>
+            <button id="undo-btn" disabled>UNDO</button>
           </div>
-          <div id="win-display" class="hidden"></div>
+          <div id="win-display" class="hidden" aria-live="polite"></div>
         </div>
 
         <div id="board-container">
           <div id="betting-board"></div>
         </div>
       </main>
+
+      <div id="game-over-overlay" class="hidden">
+        <div id="game-over-modal">
+          <h2>You're broke!</h2>
+          <p>Better luck next time.</p>
+          <button id="restart-btn">Restart with $1000</button>
+        </div>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/board.ts
+++ b/src/board.ts
@@ -11,6 +11,15 @@ const ROWS = [
   [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34],
 ]
 
+const OUTSIDE_BET_LABELS: Record<string, string> = {
+  low: 'Bet on 1-18',
+  even: 'Bet on Even',
+  red: 'Bet on Red',
+  black: 'Bet on Black',
+  odd: 'Bet on Odd',
+  high: 'Bet on 19-36',
+}
+
 export function createBoard(
   container: HTMLElement,
   onBet: BoardCallback,
@@ -22,9 +31,11 @@ export function createBoard(
 
   const table = document.createElement('div')
   table.className = 'board'
+  table.setAttribute('role', 'group')
+  table.setAttribute('aria-label', 'Roulette betting board')
 
   // Zero cell
-  const zeroCell = makeCell('0', 'green', () =>
+  const zeroCell = makeCell('0', 'green', 'Bet on number 0', () =>
     onBet({ type: 'straight', numbers: [0] }),
   )
   zeroCell.className += ' zero-cell'
@@ -37,10 +48,16 @@ export function createBoard(
   for (const row of ROWS) {
     for (const num of row) {
       const color = getPocketColor(num)
-      const cell = makeCell(String(num), color, () =>
+      const cell = makeCell(String(num), color, `Bet on number ${num}`, () =>
         onBet({ type: 'straight', numbers: [num] }),
       )
       cell.dataset['num'] = String(num)
+      if (color === 'red' || color === 'black') {
+        const cbLabel = document.createElement('span')
+        cbLabel.className = 'cb-label'
+        cbLabel.textContent = color === 'red' ? 'R' : 'B'
+        cell.appendChild(cbLabel)
+      }
       grid.appendChild(cell)
     }
   }
@@ -49,9 +66,10 @@ export function createBoard(
   // Column bets (2:1)
   const colBets = document.createElement('div')
   colBets.className = 'column-bets'
+  const colLabels = ['Bet on 3rd column', 'Bet on 2nd column', 'Bet on 1st column']
   for (let r = 0; r < 3; r++) {
     const row = ROWS[r]!
-    const cell = makeCell('2:1', 'col-bet', () =>
+    const cell = makeCell('2:1', 'col-bet', colLabels[r]!, () =>
       onBet({ type: 'column', numbers: [...row] }),
     )
     cell.dataset['betType'] = 'column'
@@ -70,7 +88,7 @@ export function createBoard(
   ]
   for (let di = 0; di < dozens.length; di++) {
     const d = dozens[di]!
-    const cell = makeCell(d.label, 'dozen-bet', () =>
+    const cell = makeCell(d.label, 'dozen-bet', `Bet on ${d.label}`, () =>
       onBet({ type: 'dozen', numbers: d.numbers }),
     )
     cell.dataset['betType'] = 'dozen'
@@ -94,7 +112,7 @@ export function createBoard(
 
   for (const ob of outsideBets) {
     const colorClass = ob.type === 'red' ? 'red' : ob.type === 'black' ? 'black' : 'outside-bet'
-    const cell = makeCell(ob.label, colorClass, () =>
+    const cell = makeCell(ob.label, colorClass, OUTSIDE_BET_LABELS[ob.type] ?? ob.label, () =>
       onBet({ type: ob.type, numbers: ob.numbers }),
     )
     outsideRow.appendChild(cell)
@@ -135,12 +153,22 @@ export function createBoard(
 function makeCell(
   text: string,
   colorClass: string,
+  ariaLabel: string,
   onClick: () => void,
 ): HTMLElement {
   const cell = document.createElement('div')
   cell.className = `cell ${colorClass}`
   cell.textContent = text
+  cell.setAttribute('role', 'button')
+  cell.setAttribute('tabindex', '0')
+  cell.setAttribute('aria-label', ariaLabel)
   cell.addEventListener('click', onClick)
+  cell.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  })
   return cell
 }
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -54,6 +54,8 @@ export function createBoard(
     const cell = makeCell('2:1', 'col-bet', () =>
       onBet({ type: 'column', numbers: [...row] }),
     )
+    cell.dataset['betType'] = 'column'
+    cell.dataset['betKey'] = `col-${r}`
     colBets.appendChild(cell)
   }
   table.appendChild(colBets)
@@ -66,10 +68,13 @@ export function createBoard(
     { label: '2nd 12', numbers: Array.from({ length: 12 }, (_, i) => i + 13) },
     { label: '3rd 12', numbers: Array.from({ length: 12 }, (_, i) => i + 25) },
   ]
-  for (const d of dozens) {
+  for (let di = 0; di < dozens.length; di++) {
+    const d = dozens[di]!
     const cell = makeCell(d.label, 'dozen-bet', () =>
       onBet({ type: 'dozen', numbers: d.numbers }),
     )
+    cell.dataset['betType'] = 'dozen'
+    cell.dataset['betKey'] = `dozen-${di}`
     dozenRow.appendChild(cell)
   }
   table.appendChild(dozenRow)
@@ -155,8 +160,18 @@ function matchesBetCell(cell: HTMLElement, bet: Bet): boolean {
     case 'even': return text === 'EVEN'
     case 'low': return text === '1-18'
     case 'high': return text === '19-36'
-    case 'column': return text === '2:1'
-    case 'dozen': return text.includes('12')
+    case 'column': {
+      if (cell.dataset['betType'] !== 'column') return false
+      const colIndex = ROWS.findIndex((row) =>
+        row.length === bet.numbers.length && row.every((n, i) => n === bet.numbers[i]),
+      )
+      return cell.dataset['betKey'] === `col-${colIndex}`
+    }
+    case 'dozen': {
+      if (cell.dataset['betType'] !== 'dozen') return false
+      const dozenIndex = bet.numbers[0] === 1 ? 0 : bet.numbers[0] === 13 ? 1 : 2
+      return cell.dataset['betKey'] === `dozen-${dozenIndex}`
+    }
     default: return false
   }
 }

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createGameState,
+  placeBet,
+  clearBets,
+  getTotalBet,
+  generateResult,
+  resolveBets,
+} from './game'
+import type { GameState } from './types'
+
+describe('createGameState', () => {
+  it('returns correct initial state with default balance', () => {
+    const state = createGameState()
+    expect(state.balance).toBe(1000)
+    expect(state.phase).toBe('betting')
+    expect(state.bets).toEqual([])
+    expect(state.selectedChip).toBe(5)
+    expect(state.lastResult).toBeNull()
+    expect(state.lastWinAmount).toBe(0)
+  })
+
+  it('accepts a custom initial balance', () => {
+    const state = createGameState(500)
+    expect(state.balance).toBe(500)
+  })
+})
+
+describe('placeBet', () => {
+  it('rejects bets when phase is not betting', () => {
+    const state = createGameState()
+    state.phase = 'spinning'
+    const result = placeBet(state, { type: 'straight', numbers: [7] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(0)
+  })
+
+  it('rejects bets when phase is result', () => {
+    const state = createGameState()
+    state.phase = 'result'
+    const result = placeBet(state, { type: 'red', numbers: [] })
+    expect(result).toBe(false)
+  })
+
+  it('rejects bets when balance is insufficient', () => {
+    const state = createGameState(10)
+    state.selectedChip = 25
+    const result = placeBet(state, { type: 'straight', numbers: [17] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(0)
+  })
+
+  it('places a bet successfully in betting phase', () => {
+    const state = createGameState()
+    const result = placeBet(state, { type: 'straight', numbers: [7] })
+    expect(result).toBe(true)
+    expect(state.bets).toHaveLength(1)
+    expect(state.bets[0]).toEqual({
+      type: 'straight',
+      numbers: [7],
+      amount: 5,
+    })
+  })
+
+  it('stacks duplicate bets by accumulating amount', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [7] })
+    expect(state.bets).toHaveLength(1)
+    expect(state.bets[0]?.amount).toBe(10)
+  })
+
+  it('does not stack bets with different numbers', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [8] })
+    expect(state.bets).toHaveLength(2)
+  })
+
+  it('does not stack bets with different types', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'split', numbers: [7, 8] })
+    expect(state.bets).toHaveLength(2)
+  })
+
+  it('rejects when remaining balance cannot cover chip value', () => {
+    const state = createGameState(10)
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [1] }) // 5 placed
+    placeBet(state, { type: 'straight', numbers: [2] }) // 5 placed, now 0 remaining
+    const result = placeBet(state, { type: 'straight', numbers: [3] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(2)
+  })
+})
+
+describe('clearBets', () => {
+  it('empties the bets array', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'red', numbers: [] })
+    expect(state.bets).toHaveLength(2)
+
+    clearBets(state)
+    expect(state.bets).toEqual([])
+  })
+
+  it('does not change balance', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    clearBets(state)
+    expect(state.balance).toBe(1000)
+  })
+})
+
+describe('getTotalBet', () => {
+  it('returns 0 with no bets', () => {
+    const state = createGameState()
+    expect(getTotalBet(state)).toBe(0)
+  })
+
+  it('returns sum of all bet amounts', () => {
+    const state = createGameState()
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [7] })
+    state.selectedChip = 25
+    placeBet(state, { type: 'red', numbers: [] })
+    expect(getTotalBet(state)).toBe(30)
+  })
+
+  it('includes stacked bet amounts', () => {
+    const state = createGameState()
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [7] })
+    expect(getTotalBet(state)).toBe(10)
+  })
+})
+
+describe('generateResult', () => {
+  it('returns a number between 0 and 36', () => {
+    for (let i = 0; i < 100; i++) {
+      const result = generateResult()
+      expect(result).toBeGreaterThanOrEqual(0)
+      expect(result).toBeLessThanOrEqual(36)
+      expect(Number.isInteger(result)).toBe(true)
+    }
+  })
+
+  it('uses crypto.getRandomValues internally', () => {
+    const spy = vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint32Array)[0] = 0
+      return array as Uint32Array
+    })
+    expect(generateResult()).toBe(0)
+
+    spy.mockImplementation((array) => {
+      (array as Uint32Array)[0] = 36
+      return array as Uint32Array
+    })
+    expect(generateResult()).toBe(36)
+
+    spy.mockRestore()
+  })
+})
+
+describe('resolveBets', () => {
+  function makeState(overrides?: Partial<GameState>): GameState {
+    return {
+      balance: 1000,
+      bets: [],
+      lastBets: [],
+      selectedChip: 5,
+      phase: 'betting',
+      lastResult: null,
+      lastWinAmount: 0,
+      ...overrides,
+    }
+  }
+
+  // -- Straight (35:1) --
+  it('pays 35:1 for winning straight bet', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    // win = 10 + 10 * 35 = 360
+    expect(win).toBe(360)
+    expect(state.balance).toBe(1000 - 10 + 360)
+    expect(state.lastResult).toBe(7)
+    expect(state.lastWinAmount).toBe(360)
+  })
+
+  it('loses straight bet when result does not match', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    const win = resolveBets(state, 8)
+    expect(win).toBe(0)
+    expect(state.balance).toBe(990)
+  })
+
+  // -- Split (17:1) --
+  it('pays 17:1 for winning split bet', () => {
+    const state = makeState({
+      bets: [{ type: 'split', numbers: [7, 8], amount: 10 }],
+    })
+    const win = resolveBets(state, 8)
+    expect(win).toBe(180) // 10 + 10*17
+    expect(state.balance).toBe(1000 - 10 + 180)
+  })
+
+  it('loses split bet when result not in pair', () => {
+    const state = makeState({
+      bets: [{ type: 'split', numbers: [7, 8], amount: 10 }],
+    })
+    const win = resolveBets(state, 9)
+    expect(win).toBe(0)
+  })
+
+  // -- Street (11:1) --
+  it('pays 11:1 for winning street bet', () => {
+    const state = makeState({
+      bets: [{ type: 'street', numbers: [1, 2, 3], amount: 10 }],
+    })
+    const win = resolveBets(state, 2)
+    expect(win).toBe(120) // 10 + 10*11
+  })
+
+  it('loses street bet when result not in row', () => {
+    const state = makeState({
+      bets: [{ type: 'street', numbers: [1, 2, 3], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(0)
+  })
+
+  // -- Corner (8:1) --
+  it('pays 8:1 for winning corner bet', () => {
+    const state = makeState({
+      bets: [{ type: 'corner', numbers: [1, 2, 4, 5], amount: 10 }],
+    })
+    const win = resolveBets(state, 5)
+    expect(win).toBe(90) // 10 + 10*8
+  })
+
+  it('loses corner bet when result not in square', () => {
+    const state = makeState({
+      bets: [{ type: 'corner', numbers: [1, 2, 4, 5], amount: 10 }],
+    })
+    const win = resolveBets(state, 6)
+    expect(win).toBe(0)
+  })
+
+  // -- Sixline (5:1) --
+  it('pays 5:1 for winning sixline bet', () => {
+    const state = makeState({
+      bets: [{ type: 'sixline', numbers: [1, 2, 3, 4, 5, 6], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(60) // 10 + 10*5
+  })
+
+  it('loses sixline bet when result outside range', () => {
+    const state = makeState({
+      bets: [{ type: 'sixline', numbers: [1, 2, 3, 4, 5, 6], amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    expect(win).toBe(0)
+  })
+
+  // -- Column (2:1) --
+  it('pays 2:1 for winning column bet', () => {
+    const col1 = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
+    const state = makeState({
+      bets: [{ type: 'column', numbers: col1, amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    expect(win).toBe(30) // 10 + 10*2
+  })
+
+  it('loses column bet when result not in column', () => {
+    const col1 = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
+    const state = makeState({
+      bets: [{ type: 'column', numbers: col1, amount: 10 }],
+    })
+    const win = resolveBets(state, 2)
+    expect(win).toBe(0)
+  })
+
+  // -- Dozen (2:1) --
+  it('pays 2:1 for winning dozen bet', () => {
+    const dozen1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    const state = makeState({
+      bets: [{ type: 'dozen', numbers: dozen1, amount: 10 }],
+    })
+    const win = resolveBets(state, 12)
+    expect(win).toBe(30)
+  })
+
+  it('loses dozen bet when result not in range', () => {
+    const dozen1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    const state = makeState({
+      bets: [{ type: 'dozen', numbers: dozen1, amount: 10 }],
+    })
+    const win = resolveBets(state, 13)
+    expect(win).toBe(0)
+  })
+
+  // -- Red (1:1) --
+  it('pays 1:1 for winning red bet', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 1) // 1 is red
+    expect(win).toBe(20) // 10 + 10*1
+  })
+
+  it('loses red bet on black number', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 2) // 2 is black
+    expect(win).toBe(0)
+  })
+
+  it('loses red bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Black (1:1) --
+  it('pays 1:1 for winning black bet', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 2) // 2 is black
+    expect(win).toBe(20)
+  })
+
+  it('loses black bet on red number', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 1) // 1 is red
+    expect(win).toBe(0)
+  })
+
+  it('loses black bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Odd (1:1) --
+  it('pays 1:1 for winning odd bet', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(20)
+  })
+
+  it('loses odd bet on even number', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(0)
+  })
+
+  it('loses odd bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Even (1:1) --
+  it('pays 1:1 for winning even bet', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(20)
+  })
+
+  it('loses even bet on odd number', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(0)
+  })
+
+  it('loses even bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Low (1:1) --
+  it('pays 1:1 for winning low bet', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 18)
+    expect(win).toBe(20)
+  })
+
+  it('loses low bet on high number', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 19)
+    expect(win).toBe(0)
+  })
+
+  it('loses low bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- High (1:1) --
+  it('pays 1:1 for winning high bet', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 19)
+    expect(win).toBe(20)
+  })
+
+  it('loses high bet on low number', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 18)
+    expect(win).toBe(0)
+  })
+
+  it('loses high bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Multiple bets --
+  it('resolves multiple bets correctly', () => {
+    const state = makeState({
+      bets: [
+        { type: 'straight', numbers: [7], amount: 10 },
+        { type: 'red', numbers: [], amount: 20 },
+        { type: 'odd', numbers: [], amount: 15 },
+      ],
+    })
+    // 7 is red and odd
+    const win = resolveBets(state, 7)
+    // straight: 10 + 10*35 = 360
+    // red: 20 + 20*1 = 40
+    // odd: 15 + 15*1 = 30
+    expect(win).toBe(430)
+    const totalBet = 10 + 20 + 15
+    expect(state.balance).toBe(1000 - totalBet + 430)
+  })
+
+  it('updates lastResult and lastWinAmount', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    resolveBets(state, 7)
+    expect(state.lastResult).toBe(7)
+    expect(state.lastWinAmount).toBe(360)
+  })
+
+  it('handles zero bets without error', () => {
+    const state = makeState()
+    const win = resolveBets(state, 7)
+    expect(win).toBe(0)
+    expect(state.balance).toBe(1000)
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ const wheelCanvas = document.getElementById('wheel-canvas') as HTMLCanvasElement
 const boardContainer = document.getElementById('board-container')!
 const gameOverOverlay = document.getElementById('game-over-overlay')!
 const restartBtn = document.getElementById('restart-btn') as HTMLButtonElement
+const colorblindToggle = document.getElementById('colorblind-toggle') as HTMLButtonElement
 
 // Wheel
 const wheel = createWheel(wheelCanvas)
@@ -165,6 +166,22 @@ function resetGame() {
 newGameBtn.addEventListener('click', resetGame)
 restartBtn.addEventListener('click', resetGame)
 
+// Colorblind mode
+function initColorblindMode() {
+  const saved = localStorage.getItem('roulette-colorblind') === 'true'
+  if (saved) {
+    boardContainer.classList.add('colorblind-mode')
+    colorblindToggle.classList.add('active')
+  }
+}
+
+colorblindToggle.addEventListener('click', () => {
+  const isActive = boardContainer.classList.toggle('colorblind-mode')
+  colorblindToggle.classList.toggle('active', isActive)
+  localStorage.setItem('roulette-colorblind', String(isActive))
+})
+
 // Init
 buildChipSelector()
+initColorblindMode()
 updateUI()

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,17 @@
+const BALANCE_KEY = 'roulette-balance'
+const DEFAULT_BALANCE = 1000
+
+export function saveBalance(balance: number): void {
+  localStorage.setItem(BALANCE_KEY, String(balance))
+}
+
+export function loadBalance(): number {
+  const stored = localStorage.getItem(BALANCE_KEY)
+  if (stored === null) return DEFAULT_BALANCE
+  const parsed = Number(stored)
+  return Number.isFinite(parsed) ? parsed : DEFAULT_BALANCE
+}
+
+export function clearSavedBalance(): void {
+  localStorage.removeItem(BALANCE_KEY)
+}

--- a/src/style.css
+++ b/src/style.css
@@ -152,7 +152,7 @@ main {
   justify-content: center;
 }
 
-#spin-btn, #clear-btn {
+#spin-btn, #clear-btn, #repeat-btn, #undo-btn {
   padding: 12px 28px;
   border: none;
   border-radius: 6px;
@@ -179,18 +179,32 @@ main {
   cursor: not-allowed;
 }
 
-#clear-btn {
+#clear-btn, #repeat-btn, #undo-btn {
   background: #333;
   color: #ccc;
 }
 
-#clear-btn:hover:not(:disabled) {
+#clear-btn:hover:not(:disabled),
+#repeat-btn:hover:not(:disabled),
+#undo-btn:hover:not(:disabled) {
   background: #444;
 }
 
-#clear-btn:disabled {
+#clear-btn:disabled,
+#repeat-btn:disabled,
+#undo-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+#repeat-btn {
+  background: linear-gradient(135deg, #2a6a3a, #1a4a2a);
+  color: #aed6a0;
+}
+
+#undo-btn {
+  background: linear-gradient(135deg, #6a3a2a, #4a2a1a);
+  color: #d6a0a0;
 }
 
 .win-message, .lose-message {
@@ -208,7 +222,7 @@ main {
 }
 
 .lose-message {
-  color: #888;
+  color: #b0b0b0;
 }
 
 /* Board */
@@ -328,6 +342,177 @@ main {
 
 .hidden {
   display: none !important;
+}
+
+/* New Game button */
+#new-game-btn {
+  padding: 8px 18px;
+  border: 1px solid #d4a34a;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4a34a;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s;
+}
+
+#new-game-btn:hover {
+  background: rgba(212, 163, 74, 0.15);
+}
+
+/* Game Over Overlay */
+#game-over-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+#game-over-modal {
+  background: linear-gradient(135deg, #1a2a1a, #0a1a0a);
+  border: 2px solid #d4a34a;
+  border-radius: 12px;
+  padding: 40px 48px;
+  text-align: center;
+  max-width: 400px;
+  width: 90%;
+}
+
+#game-over-modal h2 {
+  font-size: 2rem;
+  color: #c0392b;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+#game-over-modal p {
+  color: #aaa;
+  margin-bottom: 24px;
+  font-size: 1.1rem;
+}
+
+#restart-btn {
+  padding: 14px 32px;
+  border: none;
+  border-radius: 6px;
+  background: linear-gradient(135deg, #d4a34a, #b8862a);
+  color: #1a1a2e;
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s, transform 0.1s;
+}
+
+#restart-btn:hover {
+  background: linear-gradient(135deg, #e4b35a, #c8963a);
+  transform: scale(1.02);
+}
+
+/* Focus visible outlines for keyboard navigation */
+.cell:focus-visible,
+.chip:focus-visible,
+#spin-btn:focus-visible,
+#clear-btn:focus-visible,
+#repeat-btn:focus-visible,
+#undo-btn:focus-visible,
+#new-game-btn:focus-visible,
+#restart-btn:focus-visible {
+  outline: 3px solid #d4a34a;
+  outline-offset: 2px;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .result-badge,
+  .win-message,
+  .lose-message,
+  .chip-indicator,
+  #game-over-overlay {
+    animation: none;
+  }
+
+  .chip,
+  .cell,
+  #spin-btn,
+  #clear-btn,
+  #repeat-btn,
+  #undo-btn,
+  #new-game-btn,
+  #restart-btn {
+    transition: none;
+  }
+}
+
+/* Colorblind mode */
+.colorblind-mode .cell.red {
+  background: repeating-linear-gradient(
+    45deg,
+    #c0392b,
+    #c0392b 4px,
+    #a02a1e 4px,
+    #a02a1e 8px
+  );
+}
+
+.colorblind-mode .cell.black {
+  background: radial-gradient(circle 2px, #555 1px, transparent 1px);
+  background-size: 6px 6px;
+  background-color: #1a1a2e;
+}
+
+.colorblind-mode .cell.red .cb-label,
+.colorblind-mode .cell.black .cb-label {
+  display: block;
+  font-size: 0.6rem;
+  line-height: 1;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.cb-label {
+  display: none;
+}
+
+/* Colorblind toggle button */
+#colorblind-toggle {
+  padding: 8px 14px;
+  border: 1px solid #d4a34a;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4a34a;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s;
+}
+
+#colorblind-toggle:hover {
+  background: rgba(212, 163, 74, 0.15);
+}
+
+#colorblind-toggle.active {
+  background: rgba(212, 163, 74, 0.3);
+  border-width: 2px;
 }
 
 /* Responsive */

--- a/src/style.css
+++ b/src/style.css
@@ -332,6 +332,9 @@ main {
   border: 2px dashed rgba(255, 255, 255, 0.5);
   pointer-events: none;
   z-index: 2;
+}
+
+.chip-indicator.chip-new {
   animation: chipDrop 0.2s ease-out;
 }
 
@@ -444,7 +447,7 @@ main {
   .result-badge,
   .win-message,
   .lose-message,
-  .chip-indicator,
+  .chip-indicator.chip-new,
   #game-over-overlay {
     animation: none;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type GamePhase = 'betting' | 'spinning' | 'result'
 export type GameState = {
   balance: number
   bets: Bet[]
+  lastBets: Bet[]
   selectedChip: number
   phase: GamePhase
   lastResult: number | null

--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -23,6 +23,8 @@ export function createWheel(canvas: HTMLCanvasElement): {
   const ballR = outerR * 0.85
   const ballSize = 6
 
+  let rafId: number | null = null
+
   const state: WheelState = {
     angle: 0,
     ballAngle: 0,
@@ -121,6 +123,17 @@ export function createWheel(canvas: HTMLCanvasElement): {
   }
 
   function spin(targetNumber: number): Promise<number> {
+    // Cancel any in-progress animation
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+
+    // Guard against double-call while spinning
+    if (state.spinning) {
+      state.spinning = false
+    }
+
     return new Promise((resolve) => {
       state.spinning = true
       state.targetPocket = targetNumber
@@ -156,14 +169,15 @@ export function createWheel(canvas: HTMLCanvasElement): {
         draw()
 
         if (progress < 1) {
-          requestAnimationFrame(animate)
+          rafId = requestAnimationFrame(animate)
         } else {
+          rafId = null
           state.spinning = false
           resolve(targetNumber)
         }
       }
 
-      requestAnimationFrame(animate)
+      rafId = requestAnimationFrame(animate)
     })
   }
 

--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -122,6 +122,10 @@ export function createWheel(canvas: HTMLCanvasElement): {
     ctx.fill()
   }
 
+  function prefersReducedMotion(): boolean {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  }
+
   function spin(targetNumber: number): Promise<number> {
     // Cancel any in-progress animation
     if (rafId !== null) {
@@ -141,6 +145,16 @@ export function createWheel(canvas: HTMLCanvasElement): {
       const targetIndex = WHEEL_SEQUENCE.indexOf(targetNumber)
       // Target angle: the pocket should be at the top (negative Y = -PI/2)
       const targetPocketAngle = -Math.PI / 2 - targetIndex * POCKET_ARC
+
+      // Reduced motion: skip animation, jump directly to result
+      if (prefersReducedMotion()) {
+        state.angle = targetPocketAngle
+        state.ballAngle = -Math.PI / 2
+        state.spinning = false
+        draw()
+        resolve(targetNumber)
+        return
+      }
 
       // Wheel spins multiple full rotations + lands on target
       const totalWheelSpin = Math.PI * 2 * (5 + Math.random() * 3)

--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -3,6 +3,43 @@ import { WHEEL_SEQUENCE, getPocketColor } from './types'
 const POCKET_COUNT = 37
 const POCKET_ARC = (Math.PI * 2) / POCKET_COUNT
 
+// Geometry constants (CSS pixels)
+const CANVAS_PADDING = 10
+const INNER_RADIUS_RATIO = 0.65
+const BALL_RADIUS_RATIO = 0.85
+const TEXT_RADIUS_RATIO = 0.82
+const INNER_PATTERN_RATIO = 0.6
+const BALL_SIZE = 6
+const BALL_SHINE_OFFSET = 1.5
+const BALL_SHINE_SIZE_RATIO = 0.4
+const MARKER_OVERSHOOT = 8
+const MARKER_HALF_WIDTH = 8
+const MARKER_HEIGHT = 6
+
+// Animation constants
+const MIN_WHEEL_ROTATIONS = 5
+const EXTRA_ROTATION_RANGE = 3
+const MIN_BALL_SPINS = 8
+const EXTRA_BALL_SPIN_RANGE = 4
+const MIN_DURATION_MS = 4000
+const EXTRA_DURATION_RANGE_MS = 1500
+
+// Ball bounce constants (#29)
+const BOUNCE_DURATION_MS = 600
+const BOUNCE_COUNT = 4
+const BOUNCE_AMPLITUDE = POCKET_ARC * 0.4
+
+// Colors
+const COLOR_RED = '#c0392b'
+const COLOR_BLACK = '#1a1a2e'
+const COLOR_GREEN = '#27ae60'
+const COLOR_GOLD = '#d4a34a'
+const COLOR_WOOD = '#2a1a0a'
+const COLOR_FELT_MID = '#1a3a1a'
+const COLOR_FELT_LIGHT = '#2a5a2a'
+const COLOR_WHITE = '#fff'
+const COLOR_BALL_SHINE = 'rgba(255,255,255,0.6)'
+
 export type WheelState = {
   angle: number
   ballAngle: number
@@ -11,17 +48,28 @@ export type WheelState = {
 }
 
 export function createWheel(canvas: HTMLCanvasElement): {
-  state: WheelState
   draw: () => void
   spin: (targetNumber: number) => Promise<number>
 } {
+  // HiDPI / Retina scaling (#8)
+  const dpr = window.devicePixelRatio || 1
+  const cssWidth = canvas.clientWidth || canvas.width
+  const cssHeight = canvas.clientHeight || canvas.height
+  canvas.width = cssWidth * dpr
+  canvas.height = cssHeight * dpr
+  canvas.style.width = cssWidth + 'px'
+  canvas.style.height = cssHeight + 'px'
+
   const ctx = canvas.getContext('2d')!
-  const cx = canvas.width / 2
-  const cy = canvas.height / 2
-  const outerR = Math.min(cx, cy) - 10
-  const innerR = outerR * 0.65
-  const ballR = outerR * 0.85
-  const ballSize = 6
+  ctx.scale(dpr, dpr)
+
+  // All drawing uses CSS pixel coordinates
+  const cx = cssWidth / 2
+  const cy = cssHeight / 2
+  const outerR = Math.min(cx, cy) - CANVAS_PADDING
+  const innerR = outerR * INNER_RADIUS_RATIO
+  const ballR = outerR * BALL_RADIUS_RATIO
+  const textR = outerR * TEXT_RADIUS_RATIO
 
   let rafId: number | null = null
 
@@ -32,16 +80,56 @@ export function createWheel(canvas: HTMLCanvasElement): {
     targetPocket: null,
   }
 
-  function draw() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
+  // Off-screen canvas for static hub and marker (#19)
+  const staticCanvas = document.createElement('canvas')
+  staticCanvas.width = canvas.width
+  staticCanvas.height = canvas.height
+  const staticCtx = staticCanvas.getContext('2d')!
+  staticCtx.scale(dpr, dpr)
 
-    // Outer ring
+  function renderStaticParts() {
+    staticCtx.clearRect(0, 0, cssWidth, cssHeight)
+
+    // Inner circle (hub)
+    staticCtx.beginPath()
+    staticCtx.arc(cx, cy, innerR, 0, Math.PI * 2)
+    staticCtx.fillStyle = COLOR_FELT_MID
+    staticCtx.fill()
+    staticCtx.strokeStyle = COLOR_GOLD
+    staticCtx.lineWidth = 3
+    staticCtx.stroke()
+
+    // Decorative inner pattern
+    staticCtx.beginPath()
+    staticCtx.arc(cx, cy, innerR * INNER_PATTERN_RATIO, 0, Math.PI * 2)
+    staticCtx.fillStyle = COLOR_FELT_LIGHT
+    staticCtx.fill()
+    staticCtx.strokeStyle = COLOR_GOLD
+    staticCtx.lineWidth = 1.5
+    staticCtx.stroke()
+
+    // Marker triangle at top
+    staticCtx.beginPath()
+    staticCtx.moveTo(cx, cy - outerR - MARKER_OVERSHOOT)
+    staticCtx.lineTo(cx - MARKER_HALF_WIDTH, cy - outerR + MARKER_HEIGHT)
+    staticCtx.lineTo(cx + MARKER_HALF_WIDTH, cy - outerR + MARKER_HEIGHT)
+    staticCtx.closePath()
+    staticCtx.fillStyle = COLOR_GOLD
+    staticCtx.fill()
+  }
+
+  renderStaticParts()
+
+  function draw() {
+    ctx.clearRect(0, 0, cssWidth, cssHeight)
+
+    // Outer ring background
     ctx.beginPath()
     ctx.arc(cx, cy, outerR, 0, Math.PI * 2)
-    ctx.fillStyle = '#2a1a0a'
+    ctx.fillStyle = COLOR_WOOD
     ctx.fill()
 
-    // Draw pockets
+    // Draw pockets (rotates each frame)
     for (let i = 0; i < POCKET_COUNT; i++) {
       const startAngle = state.angle + i * POCKET_ARC - POCKET_ARC / 2
       const endAngle = startAngle + POCKET_ARC
@@ -53,23 +141,22 @@ export function createWheel(canvas: HTMLCanvasElement): {
 
       const num = WHEEL_SEQUENCE[i]!
       const color = getPocketColor(num)
-      ctx.fillStyle = color === 'red' ? '#c0392b' : color === 'black' ? '#1a1a2e' : '#27ae60'
+      ctx.fillStyle = color === 'red' ? COLOR_RED : color === 'black' ? COLOR_BLACK : COLOR_GREEN
       ctx.fill()
 
-      ctx.strokeStyle = '#d4a34a'
+      ctx.strokeStyle = COLOR_GOLD
       ctx.lineWidth = 0.5
       ctx.stroke()
 
       // Number text
       const textAngle = startAngle + POCKET_ARC / 2
-      const textR = outerR * 0.82
       ctx.save()
       ctx.translate(
         cx + Math.cos(textAngle) * textR,
         cy + Math.sin(textAngle) * textR,
       )
       ctx.rotate(textAngle + Math.PI / 2)
-      ctx.fillStyle = '#fff'
+      ctx.fillStyle = COLOR_WHITE
       ctx.font = 'bold 11px Arial'
       ctx.textAlign = 'center'
       ctx.textBaseline = 'middle'
@@ -77,23 +164,8 @@ export function createWheel(canvas: HTMLCanvasElement): {
       ctx.restore()
     }
 
-    // Inner circle (hub)
-    ctx.beginPath()
-    ctx.arc(cx, cy, innerR, 0, Math.PI * 2)
-    ctx.fillStyle = '#1a3a1a'
-    ctx.fill()
-    ctx.strokeStyle = '#d4a34a'
-    ctx.lineWidth = 3
-    ctx.stroke()
-
-    // Decorative inner pattern
-    ctx.beginPath()
-    ctx.arc(cx, cy, innerR * 0.6, 0, Math.PI * 2)
-    ctx.fillStyle = '#2a5a2a'
-    ctx.fill()
-    ctx.strokeStyle = '#d4a34a'
-    ctx.lineWidth = 1.5
-    ctx.stroke()
+    // Composite static hub and marker from off-screen canvas (#19)
+    ctx.drawImage(staticCanvas, 0, 0, cssWidth, cssHeight)
 
     // Ball
     if (state.spinning || state.targetPocket !== null) {
@@ -101,25 +173,22 @@ export function createWheel(canvas: HTMLCanvasElement): {
       const by = cy + Math.sin(state.ballAngle) * ballR
 
       ctx.beginPath()
-      ctx.arc(bx, by, ballSize, 0, Math.PI * 2)
-      ctx.fillStyle = '#fff'
+      ctx.arc(bx, by, BALL_SIZE, 0, Math.PI * 2)
+      ctx.fillStyle = COLOR_WHITE
       ctx.fill()
 
       // Ball shine
       ctx.beginPath()
-      ctx.arc(bx - 1.5, by - 1.5, ballSize * 0.4, 0, Math.PI * 2)
-      ctx.fillStyle = 'rgba(255,255,255,0.6)'
+      ctx.arc(
+        bx - BALL_SHINE_OFFSET,
+        by - BALL_SHINE_OFFSET,
+        BALL_SIZE * BALL_SHINE_SIZE_RATIO,
+        0,
+        Math.PI * 2,
+      )
+      ctx.fillStyle = COLOR_BALL_SHINE
       ctx.fill()
     }
-
-    // Marker triangle at top
-    ctx.beginPath()
-    ctx.moveTo(cx, cy - outerR - 8)
-    ctx.lineTo(cx - 8, cy - outerR + 6)
-    ctx.lineTo(cx + 8, cy - outerR + 6)
-    ctx.closePath()
-    ctx.fillStyle = '#d4a34a'
-    ctx.fill()
   }
 
   function prefersReducedMotion(): boolean {
@@ -133,7 +202,6 @@ export function createWheel(canvas: HTMLCanvasElement): {
       rafId = null
     }
 
-    // Guard against double-call while spinning
     if (state.spinning) {
       state.spinning = false
     }
@@ -143,10 +211,9 @@ export function createWheel(canvas: HTMLCanvasElement): {
       state.targetPocket = targetNumber
 
       const targetIndex = WHEEL_SEQUENCE.indexOf(targetNumber)
-      // Target angle: the pocket should be at the top (negative Y = -PI/2)
       const targetPocketAngle = -Math.PI / 2 - targetIndex * POCKET_ARC
 
-      // Reduced motion: skip animation, jump directly to result
+      // Reduced motion: skip animation
       if (prefersReducedMotion()) {
         state.angle = targetPocketAngle
         state.ballAngle = -Math.PI / 2
@@ -156,18 +223,17 @@ export function createWheel(canvas: HTMLCanvasElement): {
         return
       }
 
-      // Wheel spins multiple full rotations + lands on target
-      const totalWheelSpin = Math.PI * 2 * (5 + Math.random() * 3)
+      // Varied spin parameters (#29)
+      const totalWheelSpin = Math.PI * 2 * (MIN_WHEEL_ROTATIONS + Math.random() * EXTRA_ROTATION_RANGE)
       const wheelStart = state.angle
       const wheelEnd = wheelStart + totalWheelSpin +
         (targetPocketAngle - ((wheelStart + totalWheelSpin) % (Math.PI * 2)) + Math.PI * 4) % (Math.PI * 2)
 
-      // Ball spins opposite direction
       const ballStart = state.ballAngle
-      const totalBallSpin = -Math.PI * 2 * (8 + Math.random() * 4)
-      const ballEnd = -Math.PI / 2 // Ball lands at top
+      const totalBallSpin = -Math.PI * 2 * (MIN_BALL_SPINS + Math.random() * EXTRA_BALL_SPIN_RANGE)
+      const ballEnd = -Math.PI / 2
 
-      const duration = 4000 + Math.random() * 1000
+      const duration = MIN_DURATION_MS + Math.random() * EXTRA_DURATION_RANGE_MS
       const startTime = performance.now()
 
       function animate(now: number) {
@@ -185,8 +251,31 @@ export function createWheel(canvas: HTMLCanvasElement): {
         if (progress < 1) {
           rafId = requestAnimationFrame(animate)
         } else {
+          // Transition to ball bounce phase (#29)
+          rafId = requestAnimationFrame(bounce)
+        }
+      }
+
+      // Ball bounce oscillation after main spin settles (#29)
+      const spinEndTime = startTime + duration
+      function bounce(now: number) {
+        const bounceElapsed = now - spinEndTime
+        const bounceProgress = Math.min(bounceElapsed / BOUNCE_DURATION_MS, 1)
+
+        // Damped oscillation: amplitude decays while oscillating
+        const decay = 1 - bounceProgress
+        const oscillation = Math.sin(bounceProgress * BOUNCE_COUNT * Math.PI * 2)
+        state.ballAngle = ballEnd + oscillation * decay * BOUNCE_AMPLITUDE
+
+        draw()
+
+        if (bounceProgress < 1) {
+          rafId = requestAnimationFrame(bounce)
+        } else {
           rafId = null
+          state.ballAngle = ballEnd
           state.spinning = false
+          draw()
           resolve(targetNumber)
         }
       }
@@ -198,5 +287,5 @@ export function createWheel(canvas: HTMLCanvasElement): {
   // Initial draw
   draw()
 
-  return { state, draw, spin }
+  return { draw, spin }
 }


### PR DESCRIPTION
## Summary

- **HiDPI/Retina fix (#8)**: Scale canvas backing store by `devicePixelRatio` so the wheel renders crisply on high-DPI screens
- **Off-screen canvas (#19)**: Render static hub, inner pattern, and marker triangle once to an off-screen canvas, then composite per frame — avoids redundant draw calls
- **Diff-based chip updates (#20)**: Replace the clear-all/recreate `updateChips()` with a `Map`-based diff that only adds, removes, or updates changed chip indicators — reduces DOM thrashing and prevents re-triggering the drop animation on unchanged chips
- **Ball bounce animation (#29)**: After the main spin easing completes, the ball undergoes a damped sinusoidal oscillation (4 bounces over 600ms) before settling into the target pocket
- **CSS refinement**: `chipDrop` animation now only applies to `.chip-new` class (removed after `animationend`), and `prefers-reduced-motion` query updated accordingly

Closes #8, #19, #20, #29

## Test plan

- [ ] Verify wheel renders sharply on Retina/HiDPI displays
- [ ] Confirm static hub and marker are not redrawn each frame (no flicker, performance stable)
- [ ] Place multiple bets, spin, place more bets — chip indicators should only animate on first placement
- [ ] Observe ball bounce oscillation at end of spin animation
- [ ] Toggle `prefers-reduced-motion` and verify animations are suppressed
- [ ] Build passes: `pnpm tsc --noEmit && pnpm build`