### PR TITLE
feat: add sound effects, history panel, win feedback, statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Play European roulette in your browser with realistic wheel animation and full betting board." />
+    <meta name="theme-color" content="#0a0a12" />
+    <meta property="og:title" content="Roulette - European Casino Game" />
+    <meta property="og:description" content="Play European roulette in your browser with realistic wheel animation and full betting board." />
+    <meta property="og:type" content="website" />
     <title>Roulette</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎰</text></svg>" />
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
     <div id="app">
       <header>
         <h1>Roulette</h1>
         <div id="balance-display">Balance: <span id="balance">1000</span></div>
+        <button id="mute-toggle" aria-label="Toggle sound">Sound: ON</button>
+        <button id="theme-toggle" aria-label="Toggle light/dark theme">LT</button>
         <button id="colorblind-toggle" aria-label="Toggle colorblind mode">CB</button>
         <button id="new-game-btn">NEW GAME</button>
       </header>
@@ -37,6 +45,11 @@
           <div id="betting-board"></div>
         </div>
       </main>
+
+      <div id="panels-row">
+        <div id="history-container"></div>
+        <div id="stats-container"></div>
+      </div>
 
       <div id="game-over-overlay" class="hidden">
         <div id="game-over-modal">

--- a/index.html
+++ b/index.html
@@ -11,12 +11,14 @@
       <header>
         <h1>Roulette</h1>
         <div id="balance-display">Balance: <span id="balance">1000</span></div>
+        <button id="colorblind-toggle" aria-label="Toggle colorblind mode">CB</button>
+        <button id="new-game-btn">NEW GAME</button>
       </header>
 
       <main>
         <div id="wheel-container">
-          <canvas id="wheel-canvas" width="400" height="400"></canvas>
-          <div id="result-display" class="hidden"></div>
+          <canvas id="wheel-canvas" width="400" height="400" role="img" aria-label="Roulette wheel"></canvas>
+          <div id="result-display" class="hidden" aria-live="polite"></div>
         </div>
 
         <div id="controls">
@@ -25,14 +27,24 @@
           <div id="action-buttons">
             <button id="spin-btn" disabled>SPIN</button>
             <button id="clear-btn">CLEAR BETS</button>
+            <button id="repeat-btn" disabled>REPEAT</button>
+            <button id="undo-btn" disabled>UNDO</button>
           </div>
-          <div id="win-display" class="hidden"></div>
+          <div id="win-display" class="hidden" aria-live="polite"></div>
         </div>
 
         <div id="board-container">
           <div id="betting-board"></div>
         </div>
       </main>
+
+      <div id="game-over-overlay" class="hidden">
+        <div id="game-over-modal">
+          <h2>You're broke!</h2>
+          <p>Better luck next time.</p>
+          <button id="restart-btn">Restart with $1000</button>
+        </div>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/board.ts
+++ b/src/board.ts
@@ -11,6 +11,15 @@ const ROWS = [
   [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34],
 ]
 
+const OUTSIDE_BET_LABELS: Record<string, string> = {
+  low: 'Bet on 1-18',
+  even: 'Bet on Even',
+  red: 'Bet on Red',
+  black: 'Bet on Black',
+  odd: 'Bet on Odd',
+  high: 'Bet on 19-36',
+}
+
 export function createBoard(
   container: HTMLElement,
   onBet: BoardCallback,
@@ -22,9 +31,11 @@ export function createBoard(
 
   const table = document.createElement('div')
   table.className = 'board'
+  table.setAttribute('role', 'group')
+  table.setAttribute('aria-label', 'Roulette betting board')
 
   // Zero cell
-  const zeroCell = makeCell('0', 'green', () =>
+  const zeroCell = makeCell('0', 'green', 'Bet on number 0', () =>
     onBet({ type: 'straight', numbers: [0] }),
   )
   zeroCell.className += ' zero-cell'
@@ -37,10 +48,16 @@ export function createBoard(
   for (const row of ROWS) {
     for (const num of row) {
       const color = getPocketColor(num)
-      const cell = makeCell(String(num), color, () =>
+      const cell = makeCell(String(num), color, `Bet on number ${num}`, () =>
         onBet({ type: 'straight', numbers: [num] }),
       )
       cell.dataset['num'] = String(num)
+      if (color === 'red' || color === 'black') {
+        const cbLabel = document.createElement('span')
+        cbLabel.className = 'cb-label'
+        cbLabel.textContent = color === 'red' ? 'R' : 'B'
+        cell.appendChild(cbLabel)
+      }
       grid.appendChild(cell)
     }
   }
@@ -49,9 +66,10 @@ export function createBoard(
   // Column bets (2:1)
   const colBets = document.createElement('div')
   colBets.className = 'column-bets'
+  const colLabels = ['Bet on 3rd column', 'Bet on 2nd column', 'Bet on 1st column']
   for (let r = 0; r < 3; r++) {
     const row = ROWS[r]!
-    const cell = makeCell('2:1', 'col-bet', () =>
+    const cell = makeCell('2:1', 'col-bet', colLabels[r]!, () =>
       onBet({ type: 'column', numbers: [...row] }),
     )
     cell.dataset['betType'] = 'column'
@@ -70,7 +88,7 @@ export function createBoard(
   ]
   for (let di = 0; di < dozens.length; di++) {
     const d = dozens[di]!
-    const cell = makeCell(d.label, 'dozen-bet', () =>
+    const cell = makeCell(d.label, 'dozen-bet', `Bet on ${d.label}`, () =>
       onBet({ type: 'dozen', numbers: d.numbers }),
     )
     cell.dataset['betType'] = 'dozen'
@@ -94,7 +112,7 @@ export function createBoard(
 
   for (const ob of outsideBets) {
     const colorClass = ob.type === 'red' ? 'red' : ob.type === 'black' ? 'black' : 'outside-bet'
-    const cell = makeCell(ob.label, colorClass, () =>
+    const cell = makeCell(ob.label, colorClass, OUTSIDE_BET_LABELS[ob.type] ?? ob.label, () =>
       onBet({ type: ob.type, numbers: ob.numbers }),
     )
     outsideRow.appendChild(cell)
@@ -135,12 +153,22 @@ export function createBoard(
 function makeCell(
   text: string,
   colorClass: string,
+  ariaLabel: string,
   onClick: () => void,
 ): HTMLElement {
   const cell = document.createElement('div')
   cell.className = `cell ${colorClass}`
   cell.textContent = text
+  cell.setAttribute('role', 'button')
+  cell.setAttribute('tabindex', '0')
+  cell.setAttribute('aria-label', ariaLabel)
   cell.addEventListener('click', onClick)
+  cell.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  })
   return cell
 }
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -54,6 +54,8 @@ export function createBoard(
     const cell = makeCell('2:1', 'col-bet', () =>
       onBet({ type: 'column', numbers: [...row] }),
     )
+    cell.dataset['betType'] = 'column'
+    cell.dataset['betKey'] = `col-${r}`
     colBets.appendChild(cell)
   }
   table.appendChild(colBets)
@@ -66,10 +68,13 @@ export function createBoard(
     { label: '2nd 12', numbers: Array.from({ length: 12 }, (_, i) => i + 13) },
     { label: '3rd 12', numbers: Array.from({ length: 12 }, (_, i) => i + 25) },
   ]
-  for (const d of dozens) {
+  for (let di = 0; di < dozens.length; di++) {
+    const d = dozens[di]!
     const cell = makeCell(d.label, 'dozen-bet', () =>
       onBet({ type: 'dozen', numbers: d.numbers }),
     )
+    cell.dataset['betType'] = 'dozen'
+    cell.dataset['betKey'] = `dozen-${di}`
     dozenRow.appendChild(cell)
   }
   table.appendChild(dozenRow)
@@ -155,8 +160,18 @@ function matchesBetCell(cell: HTMLElement, bet: Bet): boolean {
     case 'even': return text === 'EVEN'
     case 'low': return text === '1-18'
     case 'high': return text === '19-36'
-    case 'column': return text === '2:1'
-    case 'dozen': return text.includes('12')
+    case 'column': {
+      if (cell.dataset['betType'] !== 'column') return false
+      const colIndex = ROWS.findIndex((row) =>
+        row.length === bet.numbers.length && row.every((n, i) => n === bet.numbers[i]),
+      )
+      return cell.dataset['betKey'] === `col-${colIndex}`
+    }
+    case 'dozen': {
+      if (cell.dataset['betType'] !== 'dozen') return false
+      const dozenIndex = bet.numbers[0] === 1 ? 0 : bet.numbers[0] === 13 ? 1 : 2
+      return cell.dataset['betKey'] === `dozen-${dozenIndex}`
+    }
     default: return false
   }
 }

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,0 +1,135 @@
+import { type Bet } from './types'
+
+export type FeedbackManager = {
+  highlightResult: (result: number, bets: Bet[], boardEl: HTMLElement) => void
+  animateBalance: (el: HTMLElement, from: number, to: number) => void
+  showConfetti: (container: HTMLElement) => void
+}
+
+export function createFeedbackManager(): FeedbackManager {
+  function highlightResult(
+    result: number,
+    bets: Bet[],
+    boardEl: HTMLElement,
+  ): void {
+    // Flash the winning number cell green
+    const winCell = boardEl.querySelector(`[data-num="${result}"]`) as HTMLElement | null
+    if (winCell) {
+      winCell.classList.add('cell-win-flash')
+      setTimeout(() => winCell.classList.remove('cell-win-flash'), 2000)
+    }
+
+    if (result === 0) {
+      const zeroCell = boardEl.querySelector('.zero-cell') as HTMLElement | null
+      if (zeroCell) {
+        zeroCell.classList.add('cell-win-flash')
+        setTimeout(() => zeroCell.classList.remove('cell-win-flash'), 2000)
+      }
+    }
+
+    // Flash losing straight bet cells red
+    for (const bet of bets) {
+      if (bet.type === 'straight' && !bet.numbers.includes(result)) {
+        const num = bet.numbers[0]
+        const selector = num === 0 ? '.zero-cell' : `[data-num="${num}"]`
+        const cell = boardEl.querySelector(selector) as HTMLElement | null
+        if (cell) {
+          cell.classList.add('cell-lose-flash')
+          setTimeout(() => cell.classList.remove('cell-lose-flash'), 1500)
+        }
+      }
+    }
+  }
+
+  function animateBalance(el: HTMLElement, from: number, to: number): void {
+    if (from === to) return
+
+    const duration = 800
+    const start = performance.now()
+    const direction = to > from ? 'balance-up' : 'balance-down'
+    el.classList.add(direction)
+
+    function tick(now: number) {
+      const elapsed = now - start
+      const progress = Math.min(elapsed / duration, 1)
+      const ease = 1 - (1 - progress) * (1 - progress)
+      const current = Math.round(from + (to - from) * ease)
+      el.textContent = String(current)
+
+      if (progress < 1) {
+        requestAnimationFrame(tick)
+      } else {
+        el.textContent = String(to)
+        el.classList.remove(direction)
+      }
+    }
+
+    requestAnimationFrame(tick)
+  }
+
+  function showConfetti(container: HTMLElement): void {
+    const canvas = document.createElement('canvas')
+    canvas.className = 'confetti-canvas'
+    canvas.width = container.clientWidth || 800
+    canvas.height = container.clientHeight || 600
+    container.appendChild(canvas)
+
+    const ctx = canvas.getContext('2d')!
+
+    type Particle = {
+      x: number; y: number; vx: number; vy: number
+      color: string; size: number; rotation: number; rotSpeed: number
+    }
+
+    const particles: Particle[] = []
+    const colors = ['#d4a34a', '#c0392b', '#2ecc71', '#3498db', '#e74c3c', '#f39c12']
+
+    for (let i = 0; i < 80; i++) {
+      particles.push({
+        x: canvas.width / 2 + (Math.random() - 0.5) * 200,
+        y: canvas.height / 3,
+        vx: (Math.random() - 0.5) * 12,
+        vy: -Math.random() * 10 - 3,
+        color: colors[Math.floor(Math.random() * colors.length)]!,
+        size: Math.random() * 6 + 3,
+        rotation: Math.random() * Math.PI * 2,
+        rotSpeed: (Math.random() - 0.5) * 0.3,
+      })
+    }
+
+    const startTime = performance.now()
+    const duration = 2500
+
+    function animate(now: number) {
+      const elapsed = now - startTime
+      if (elapsed > duration) {
+        canvas.remove()
+        return
+      }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      const life = Math.max(0, 1 - elapsed / duration)
+
+      for (const p of particles) {
+        p.x += p.vx
+        p.vy += 0.25
+        p.y += p.vy
+        p.rotation += p.rotSpeed
+
+        ctx.save()
+        ctx.translate(p.x, p.y)
+        ctx.rotate(p.rotation)
+        ctx.globalAlpha = life
+        ctx.fillStyle = p.color
+        ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6)
+        ctx.restore()
+      }
+
+      requestAnimationFrame(animate)
+    }
+
+    requestAnimationFrame(animate)
+  }
+
+  return { highlightResult, animateBalance, showConfetti }
+}

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createGameState,
+  placeBet,
+  clearBets,
+  getTotalBet,
+  generateResult,
+  resolveBets,
+} from './game'
+import type { GameState } from './types'
+
+describe('createGameState', () => {
+  it('returns correct initial state with default balance', () => {
+    const state = createGameState()
+    expect(state.balance).toBe(1000)
+    expect(state.phase).toBe('betting')
+    expect(state.bets).toEqual([])
+    expect(state.selectedChip).toBe(5)
+    expect(state.lastResult).toBeNull()
+    expect(state.lastWinAmount).toBe(0)
+  })
+
+  it('accepts a custom initial balance', () => {
+    const state = createGameState(500)
+    expect(state.balance).toBe(500)
+  })
+})
+
+describe('placeBet', () => {
+  it('rejects bets when phase is not betting', () => {
+    const state = createGameState()
+    state.phase = 'spinning'
+    const result = placeBet(state, { type: 'straight', numbers: [7] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(0)
+  })
+
+  it('rejects bets when phase is result', () => {
+    const state = createGameState()
+    state.phase = 'result'
+    const result = placeBet(state, { type: 'red', numbers: [] })
+    expect(result).toBe(false)
+  })
+
+  it('rejects bets when balance is insufficient', () => {
+    const state = createGameState(10)
+    state.selectedChip = 25
+    const result = placeBet(state, { type: 'straight', numbers: [17] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(0)
+  })
+
+  it('places a bet successfully in betting phase', () => {
+    const state = createGameState()
+    const result = placeBet(state, { type: 'straight', numbers: [7] })
+    expect(result).toBe(true)
+    expect(state.bets).toHaveLength(1)
+    expect(state.bets[0]).toEqual({
+      type: 'straight',
+      numbers: [7],
+      amount: 5,
+    })
+  })
+
+  it('stacks duplicate bets by accumulating amount', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [7] })
+    expect(state.bets).toHaveLength(1)
+    expect(state.bets[0]?.amount).toBe(10)
+  })
+
+  it('does not stack bets with different numbers', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [8] })
+    expect(state.bets).toHaveLength(2)
+  })
+
+  it('does not stack bets with different types', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'split', numbers: [7, 8] })
+    expect(state.bets).toHaveLength(2)
+  })
+
+  it('rejects when remaining balance cannot cover chip value', () => {
+    const state = createGameState(10)
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [1] }) // 5 placed
+    placeBet(state, { type: 'straight', numbers: [2] }) // 5 placed, now 0 remaining
+    const result = placeBet(state, { type: 'straight', numbers: [3] })
+    expect(result).toBe(false)
+    expect(state.bets).toHaveLength(2)
+  })
+})
+
+describe('clearBets', () => {
+  it('empties the bets array', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'red', numbers: [] })
+    expect(state.bets).toHaveLength(2)
+
+    clearBets(state)
+    expect(state.bets).toEqual([])
+  })
+
+  it('does not change balance', () => {
+    const state = createGameState()
+    placeBet(state, { type: 'straight', numbers: [7] })
+    clearBets(state)
+    expect(state.balance).toBe(1000)
+  })
+})
+
+describe('getTotalBet', () => {
+  it('returns 0 with no bets', () => {
+    const state = createGameState()
+    expect(getTotalBet(state)).toBe(0)
+  })
+
+  it('returns sum of all bet amounts', () => {
+    const state = createGameState()
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [7] })
+    state.selectedChip = 25
+    placeBet(state, { type: 'red', numbers: [] })
+    expect(getTotalBet(state)).toBe(30)
+  })
+
+  it('includes stacked bet amounts', () => {
+    const state = createGameState()
+    state.selectedChip = 5
+    placeBet(state, { type: 'straight', numbers: [7] })
+    placeBet(state, { type: 'straight', numbers: [7] })
+    expect(getTotalBet(state)).toBe(10)
+  })
+})
+
+describe('generateResult', () => {
+  it('returns a number between 0 and 36', () => {
+    for (let i = 0; i < 100; i++) {
+      const result = generateResult()
+      expect(result).toBeGreaterThanOrEqual(0)
+      expect(result).toBeLessThanOrEqual(36)
+      expect(Number.isInteger(result)).toBe(true)
+    }
+  })
+
+  it('uses crypto.getRandomValues internally', () => {
+    const spy = vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint32Array)[0] = 0
+      return array as Uint32Array
+    })
+    expect(generateResult()).toBe(0)
+
+    spy.mockImplementation((array) => {
+      (array as Uint32Array)[0] = 36
+      return array as Uint32Array
+    })
+    expect(generateResult()).toBe(36)
+
+    spy.mockRestore()
+  })
+})
+
+describe('resolveBets', () => {
+  function makeState(overrides?: Partial<GameState>): GameState {
+    return {
+      balance: 1000,
+      bets: [],
+      lastBets: [],
+      selectedChip: 5,
+      phase: 'betting',
+      lastResult: null,
+      lastWinAmount: 0,
+      ...overrides,
+    }
+  }
+
+  // -- Straight (35:1) --
+  it('pays 35:1 for winning straight bet', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    // win = 10 + 10 * 35 = 360
+    expect(win).toBe(360)
+    expect(state.balance).toBe(1000 - 10 + 360)
+    expect(state.lastResult).toBe(7)
+    expect(state.lastWinAmount).toBe(360)
+  })
+
+  it('loses straight bet when result does not match', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    const win = resolveBets(state, 8)
+    expect(win).toBe(0)
+    expect(state.balance).toBe(990)
+  })
+
+  // -- Split (17:1) --
+  it('pays 17:1 for winning split bet', () => {
+    const state = makeState({
+      bets: [{ type: 'split', numbers: [7, 8], amount: 10 }],
+    })
+    const win = resolveBets(state, 8)
+    expect(win).toBe(180) // 10 + 10*17
+    expect(state.balance).toBe(1000 - 10 + 180)
+  })
+
+  it('loses split bet when result not in pair', () => {
+    const state = makeState({
+      bets: [{ type: 'split', numbers: [7, 8], amount: 10 }],
+    })
+    const win = resolveBets(state, 9)
+    expect(win).toBe(0)
+  })
+
+  // -- Street (11:1) --
+  it('pays 11:1 for winning street bet', () => {
+    const state = makeState({
+      bets: [{ type: 'street', numbers: [1, 2, 3], amount: 10 }],
+    })
+    const win = resolveBets(state, 2)
+    expect(win).toBe(120) // 10 + 10*11
+  })
+
+  it('loses street bet when result not in row', () => {
+    const state = makeState({
+      bets: [{ type: 'street', numbers: [1, 2, 3], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(0)
+  })
+
+  // -- Corner (8:1) --
+  it('pays 8:1 for winning corner bet', () => {
+    const state = makeState({
+      bets: [{ type: 'corner', numbers: [1, 2, 4, 5], amount: 10 }],
+    })
+    const win = resolveBets(state, 5)
+    expect(win).toBe(90) // 10 + 10*8
+  })
+
+  it('loses corner bet when result not in square', () => {
+    const state = makeState({
+      bets: [{ type: 'corner', numbers: [1, 2, 4, 5], amount: 10 }],
+    })
+    const win = resolveBets(state, 6)
+    expect(win).toBe(0)
+  })
+
+  // -- Sixline (5:1) --
+  it('pays 5:1 for winning sixline bet', () => {
+    const state = makeState({
+      bets: [{ type: 'sixline', numbers: [1, 2, 3, 4, 5, 6], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(60) // 10 + 10*5
+  })
+
+  it('loses sixline bet when result outside range', () => {
+    const state = makeState({
+      bets: [{ type: 'sixline', numbers: [1, 2, 3, 4, 5, 6], amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    expect(win).toBe(0)
+  })
+
+  // -- Column (2:1) --
+  it('pays 2:1 for winning column bet', () => {
+    const col1 = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
+    const state = makeState({
+      bets: [{ type: 'column', numbers: col1, amount: 10 }],
+    })
+    const win = resolveBets(state, 7)
+    expect(win).toBe(30) // 10 + 10*2
+  })
+
+  it('loses column bet when result not in column', () => {
+    const col1 = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
+    const state = makeState({
+      bets: [{ type: 'column', numbers: col1, amount: 10 }],
+    })
+    const win = resolveBets(state, 2)
+    expect(win).toBe(0)
+  })
+
+  // -- Dozen (2:1) --
+  it('pays 2:1 for winning dozen bet', () => {
+    const dozen1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    const state = makeState({
+      bets: [{ type: 'dozen', numbers: dozen1, amount: 10 }],
+    })
+    const win = resolveBets(state, 12)
+    expect(win).toBe(30)
+  })
+
+  it('loses dozen bet when result not in range', () => {
+    const dozen1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    const state = makeState({
+      bets: [{ type: 'dozen', numbers: dozen1, amount: 10 }],
+    })
+    const win = resolveBets(state, 13)
+    expect(win).toBe(0)
+  })
+
+  // -- Red (1:1) --
+  it('pays 1:1 for winning red bet', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 1) // 1 is red
+    expect(win).toBe(20) // 10 + 10*1
+  })
+
+  it('loses red bet on black number', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 2) // 2 is black
+    expect(win).toBe(0)
+  })
+
+  it('loses red bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'red', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Black (1:1) --
+  it('pays 1:1 for winning black bet', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 2) // 2 is black
+    expect(win).toBe(20)
+  })
+
+  it('loses black bet on red number', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 1) // 1 is red
+    expect(win).toBe(0)
+  })
+
+  it('loses black bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'black', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Odd (1:1) --
+  it('pays 1:1 for winning odd bet', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(20)
+  })
+
+  it('loses odd bet on even number', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(0)
+  })
+
+  it('loses odd bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'odd', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Even (1:1) --
+  it('pays 1:1 for winning even bet', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 4)
+    expect(win).toBe(20)
+  })
+
+  it('loses even bet on odd number', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 3)
+    expect(win).toBe(0)
+  })
+
+  it('loses even bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'even', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Low (1:1) --
+  it('pays 1:1 for winning low bet', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 18)
+    expect(win).toBe(20)
+  })
+
+  it('loses low bet on high number', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 19)
+    expect(win).toBe(0)
+  })
+
+  it('loses low bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'low', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- High (1:1) --
+  it('pays 1:1 for winning high bet', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 19)
+    expect(win).toBe(20)
+  })
+
+  it('loses high bet on low number', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 18)
+    expect(win).toBe(0)
+  })
+
+  it('loses high bet on zero', () => {
+    const state = makeState({
+      bets: [{ type: 'high', numbers: [], amount: 10 }],
+    })
+    const win = resolveBets(state, 0)
+    expect(win).toBe(0)
+  })
+
+  // -- Multiple bets --
+  it('resolves multiple bets correctly', () => {
+    const state = makeState({
+      bets: [
+        { type: 'straight', numbers: [7], amount: 10 },
+        { type: 'red', numbers: [], amount: 20 },
+        { type: 'odd', numbers: [], amount: 15 },
+      ],
+    })
+    // 7 is red and odd
+    const win = resolveBets(state, 7)
+    // straight: 10 + 10*35 = 360
+    // red: 20 + 20*1 = 40
+    // odd: 15 + 15*1 = 30
+    expect(win).toBe(430)
+    const totalBet = 10 + 20 + 15
+    expect(state.balance).toBe(1000 - totalBet + 430)
+  })
+
+  it('updates lastResult and lastWinAmount', () => {
+    const state = makeState({
+      bets: [{ type: 'straight', numbers: [7], amount: 10 }],
+    })
+    resolveBets(state, 7)
+    expect(state.lastResult).toBe(7)
+    expect(state.lastWinAmount).toBe(360)
+  })
+
+  it('handles zero bets without error', () => {
+    const state = makeState()
+    const win = resolveBets(state, 7)
+    expect(win).toBe(0)
+    expect(state.balance).toBe(1000)
+  })
+})

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,133 @@
+import { type Bet, getPocketColor } from './types'
+
+const STORAGE_KEY = 'roulette-history'
+const MAX_ENTRIES = 20
+
+type HistoryEntry = {
+  result: number
+  totalBet: number
+  winAmount: number
+}
+
+export type HistoryManager = {
+  addEntry: (result: number, bets: Bet[], winAmount: number) => void
+  clear: () => void
+  render: () => void
+}
+
+export function createHistoryManager(container: HTMLElement): HistoryManager {
+  let entries: HistoryEntry[] = loadHistory()
+
+  function addEntry(result: number, bets: Bet[], winAmount: number): void {
+    const totalBet = bets.reduce((sum, b) => sum + b.amount, 0)
+    entries.unshift({ result, totalBet, winAmount })
+    if (entries.length > MAX_ENTRIES) entries.pop()
+    saveHistory(entries)
+    render()
+  }
+
+  function clear(): void {
+    entries = []
+    saveHistory(entries)
+    render()
+  }
+
+  function render(): void {
+    while (container.firstChild) container.removeChild(container.firstChild)
+
+    const header = document.createElement('div')
+    header.className = 'history-header'
+
+    const title = document.createElement('button')
+    title.className = 'history-toggle'
+    title.textContent = 'History'
+    title.setAttribute('aria-expanded', 'true')
+
+    const clearBtn = document.createElement('button')
+    clearBtn.className = 'history-clear-btn'
+    clearBtn.textContent = 'Clear'
+    clearBtn.addEventListener('click', clear)
+
+    header.appendChild(title)
+    header.appendChild(clearBtn)
+    container.appendChild(header)
+
+    const content = document.createElement('div')
+    content.className = 'history-content'
+
+    title.addEventListener('click', () => {
+      const collapsed = content.classList.toggle('collapsed')
+      title.setAttribute('aria-expanded', String(!collapsed))
+    })
+
+    // Results strip (dots)
+    const strip = document.createElement('div')
+    strip.className = 'results-strip'
+    for (const entry of entries) {
+      const dot = document.createElement('span')
+      const color = getPocketColor(entry.result)
+      dot.className = `result-dot ${color}`
+      dot.textContent = String(entry.result)
+      strip.appendChild(dot)
+    }
+    content.appendChild(strip)
+
+    // Detailed list
+    const list = document.createElement('div')
+    list.className = 'history-list'
+
+    if (entries.length === 0) {
+      const empty = document.createElement('span')
+      empty.className = 'history-empty'
+      empty.textContent = 'No spins yet'
+      list.appendChild(empty)
+    } else {
+      for (const entry of entries) {
+        const row = document.createElement('div')
+        row.className = 'history-entry'
+
+        const dot = document.createElement('span')
+        const color = getPocketColor(entry.result)
+        dot.className = `result-dot ${color}`
+        dot.textContent = String(entry.result)
+
+        const info = document.createElement('span')
+        info.className = 'history-bet-info'
+        info.textContent = `Bet: $${entry.totalBet}`
+
+        const net = document.createElement('span')
+        const netAmount = entry.winAmount - entry.totalBet
+        net.className = netAmount >= 0 ? 'history-net-win' : 'history-net-loss'
+        net.textContent = `${netAmount >= 0 ? '+' : ''}$${netAmount}`
+
+        row.appendChild(dot)
+        row.appendChild(info)
+        row.appendChild(net)
+        list.appendChild(row)
+      }
+    }
+
+    content.appendChild(list)
+    container.appendChild(content)
+  }
+
+  render()
+
+  return { addEntry, clear, render }
+}
+
+function loadHistory(): HistoryEntry[] {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed as HistoryEntry[]
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(entries: HistoryEntry[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ const wheelCanvas = document.getElementById('wheel-canvas') as HTMLCanvasElement
 const boardContainer = document.getElementById('board-container')!
 const gameOverOverlay = document.getElementById('game-over-overlay')!
 const restartBtn = document.getElementById('restart-btn') as HTMLButtonElement
+const colorblindToggle = document.getElementById('colorblind-toggle') as HTMLButtonElement
 
 // Wheel
 const wheel = createWheel(wheelCanvas)
@@ -165,6 +166,22 @@ function resetGame() {
 newGameBtn.addEventListener('click', resetGame)
 restartBtn.addEventListener('click', resetGame)
 
+// Colorblind mode
+function initColorblindMode() {
+  const saved = localStorage.getItem('roulette-colorblind') === 'true'
+  if (saved) {
+    boardContainer.classList.add('colorblind-mode')
+    colorblindToggle.classList.add('active')
+  }
+}
+
+colorblindToggle.addEventListener('click', () => {
+  const isActive = boardContainer.classList.toggle('colorblind-mode')
+  colorblindToggle.classList.toggle('active', isActive)
+  localStorage.setItem('roulette-colorblind', String(isActive))
+})
+
 // Init
 buildChipSelector()
+initColorblindMode()
 updateUI()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import './style.css'
+import './ux-styles.css'
 import { createWheel } from './wheel'
 import { createBoard } from './board'
 import {
@@ -12,8 +13,12 @@ import {
   repeatBets,
   undoLastBet,
 } from './game'
-import { CHIP_VALUES, getPocketColor } from './types'
+import { type Bet, CHIP_VALUES, getPocketColor } from './types'
 import { saveBalance, loadBalance, clearSavedBalance } from './storage'
+import { createSoundManager } from './sound'
+import { createHistoryManager } from './history'
+import { createFeedbackManager } from './feedback'
+import { createStatsManager } from './stats'
 
 let state = createGameState(loadBalance())
 
@@ -33,6 +38,16 @@ const boardContainer = document.getElementById('board-container')!
 const gameOverOverlay = document.getElementById('game-over-overlay')!
 const restartBtn = document.getElementById('restart-btn') as HTMLButtonElement
 const colorblindToggle = document.getElementById('colorblind-toggle') as HTMLButtonElement
+const muteToggle = document.getElementById('mute-toggle') as HTMLButtonElement
+const themeToggle = document.getElementById('theme-toggle') as HTMLButtonElement
+const historyContainer = document.getElementById('history-container')!
+const statsContainer = document.getElementById('stats-container')!
+
+// UX managers
+const sound = createSoundManager()
+const history = createHistoryManager(historyContainer)
+const feedback = createFeedbackManager()
+const statsManager = createStatsManager(statsContainer)
 
 // Wheel
 const wheel = createWheel(wheelCanvas)
@@ -41,6 +56,7 @@ const wheel = createWheel(wheelCanvas)
 const board = createBoard(boardContainer, (bet) => {
   if (state.phase !== 'betting') return
   if (placeBet(state, bet)) {
+    sound.play('chip')
     updateUI()
   }
 })
@@ -69,6 +85,17 @@ function updateChipSelection() {
   })
 }
 
+// Mute toggle
+function updateMuteButton() {
+  muteToggle.textContent = sound.muted ? 'Sound: OFF' : 'Sound: ON'
+  muteToggle.classList.toggle('active', !sound.muted)
+}
+
+muteToggle.addEventListener('click', () => {
+  sound.toggle()
+  updateMuteButton()
+})
+
 // UI update
 function updateUI() {
   balanceEl.textContent = String(state.balance)
@@ -92,16 +119,29 @@ function updateUI() {
 spinBtn.addEventListener('click', async () => {
   if (state.phase !== 'betting' || state.bets.length === 0) return
 
+  const betsSnapshot: Bet[] = state.bets.map((b) => ({ ...b }))
+  const balanceBefore = state.balance
+
   state.phase = 'spinning'
   updateUI()
   resultDisplay.classList.add('hidden')
   winDisplay.classList.add('hidden')
 
+  sound.play('spin')
+
   const result = generateResult()
   await wheel.spin(result)
 
+  sound.play('ballClatter')
+
   const winAmount = resolveBets(state, result)
   saveBalance(state.balance)
+
+  // Feedback: highlight winning/losing cells
+  feedback.highlightResult(result, betsSnapshot, boardContainer)
+
+  // Feedback: animate balance change
+  feedback.animateBalance(balanceEl, balanceBefore, state.balance)
 
   // Show result
   const color = getPocketColor(result)
@@ -109,15 +149,31 @@ spinBtn.addEventListener('click', async () => {
   resultDisplay.className = `result-badge ${color}`
   resultDisplay.classList.remove('hidden')
 
+  // Determine if big win (straight bet win = 35:1 payout)
+  const isBigWin = betsSnapshot.some(
+    (b) => b.type === 'straight' && b.numbers.includes(result),
+  )
+
   // Show win/loss
   if (winAmount > 0) {
     winDisplay.textContent = `WIN +${winAmount}!`
     winDisplay.className = 'win-message'
+    if (isBigWin) {
+      sound.play('bigWin')
+      feedback.showConfetti(document.getElementById('app')!)
+    } else {
+      sound.play('win')
+    }
   } else {
     winDisplay.textContent = 'No win'
     winDisplay.className = 'lose-message'
+    sound.play('lose')
   }
   winDisplay.classList.remove('hidden')
+
+  // Record to history and stats
+  history.addEntry(result, betsSnapshot, winAmount)
+  statsManager.recordRound(betsSnapshot, winAmount, result)
 
   state.phase = 'result'
   state.bets = []
@@ -143,6 +199,7 @@ clearBtn.addEventListener('click', () => {
 // Repeat handler
 repeatBtn.addEventListener('click', () => {
   if (repeatBets(state)) {
+    sound.play('chip')
     updateUI()
   }
 })
@@ -160,6 +217,8 @@ function resetGame() {
   state = createGameState()
   resultDisplay.classList.add('hidden')
   winDisplay.classList.add('hidden')
+  history.clear()
+  statsManager.clear()
   updateUI()
 }
 
@@ -181,7 +240,61 @@ colorblindToggle.addEventListener('click', () => {
   localStorage.setItem('roulette-colorblind', String(isActive))
 })
 
+// Dark/light theme toggle (#32)
+function initTheme() {
+  const saved = localStorage.getItem('roulette-theme')
+  if (saved === 'light') {
+    document.documentElement.classList.add('light-theme')
+    themeToggle.textContent = 'DK'
+  }
+}
+
+themeToggle.addEventListener('click', () => {
+  const isLight = document.documentElement.classList.toggle('light-theme')
+  localStorage.setItem('roulette-theme', isLight ? 'light' : 'dark')
+  themeToggle.textContent = isLight ? 'DK' : 'LT'
+})
+
+// Keyboard shortcuts (#26)
+const CHIP_KEY_MAP: Record<string, number> = { '1': 0, '2': 1, '3': 2, '4': 3 }
+
+document.addEventListener('keydown', (e) => {
+  const tag = (e.target as HTMLElement).tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return
+
+  switch (e.key) {
+    case ' ': {
+      e.preventDefault()
+      if (!spinBtn.disabled) spinBtn.click()
+      break
+    }
+    case 'Escape': {
+      if (!clearBtn.disabled) clearBtn.click()
+      break
+    }
+    case 'r':
+    case 'R': {
+      if (!repeatBtn.disabled) repeatBtn.click()
+      break
+    }
+    case 'z':
+    case 'Z': {
+      if (!undoBtn.disabled) undoBtn.click()
+      break
+    }
+    default: {
+      const chipIndex = CHIP_KEY_MAP[e.key]
+      if (chipIndex !== undefined && CHIP_VALUES[chipIndex] !== undefined) {
+        state.selectedChip = CHIP_VALUES[chipIndex]
+        updateChipSelection()
+      }
+    }
+  }
+})
+
 // Init
 buildChipSelector()
 initColorblindMode()
+initTheme()
+updateMuteButton()
 updateUI()

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -1,0 +1,166 @@
+export type SoundName = 'chip' | 'spin' | 'ballClatter' | 'win' | 'lose' | 'bigWin'
+
+export type SoundManager = {
+  muted: boolean
+  toggle: () => void
+  play: (name: SoundName) => void
+}
+
+export function createSoundManager(): SoundManager {
+  let ctx: AudioContext | null = null
+  let muted = localStorage.getItem('roulette-muted') === 'true'
+
+  // Respect prefers-reduced-motion
+  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+  const prefersReduced = motionQuery.matches
+
+  function getCtx(): AudioContext | null {
+    if (prefersReduced) return null
+    if (!ctx) {
+      try {
+        ctx = new AudioContext()
+      } catch {
+        return null
+      }
+    }
+    if (ctx.state === 'suspended') {
+      ctx.resume().catch(() => {})
+    }
+    return ctx
+  }
+
+  function playChip(): void {
+    const ac = getCtx()
+    if (!ac) return
+    const osc = ac.createOscillator()
+    const gain = ac.createGain()
+    osc.connect(gain)
+    gain.connect(ac.destination)
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(800, ac.currentTime)
+    osc.frequency.exponentialRampToValueAtTime(1200, ac.currentTime + 0.05)
+    gain.gain.setValueAtTime(0.15, ac.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 0.1)
+    osc.start(ac.currentTime)
+    osc.stop(ac.currentTime + 0.1)
+  }
+
+  function playSpin(): void {
+    const ac = getCtx()
+    if (!ac) return
+    const osc = ac.createOscillator()
+    const gain = ac.createGain()
+    osc.connect(gain)
+    gain.connect(ac.destination)
+    osc.type = 'sawtooth'
+    osc.frequency.setValueAtTime(150, ac.currentTime)
+    osc.frequency.exponentialRampToValueAtTime(60, ac.currentTime + 2)
+    gain.gain.setValueAtTime(0.08, ac.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 2)
+    osc.start(ac.currentTime)
+    osc.stop(ac.currentTime + 2)
+  }
+
+  function playBallClatter(): void {
+    const ac = getCtx()
+    if (!ac) return
+    for (let i = 0; i < 5; i++) {
+      const osc = ac.createOscillator()
+      const gain = ac.createGain()
+      osc.connect(gain)
+      gain.connect(ac.destination)
+      osc.type = 'square'
+      const time = ac.currentTime + i * 0.08
+      osc.frequency.setValueAtTime(2000 - i * 200, time)
+      gain.gain.setValueAtTime(0.06, time)
+      gain.gain.exponentialRampToValueAtTime(0.001, time + 0.06)
+      osc.start(time)
+      osc.stop(time + 0.06)
+    }
+  }
+
+  function playWin(): void {
+    const ac = getCtx()
+    if (!ac) return
+    const notes = [523, 659, 784]
+    for (let i = 0; i < notes.length; i++) {
+      const osc = ac.createOscillator()
+      const gain = ac.createGain()
+      osc.connect(gain)
+      gain.connect(ac.destination)
+      osc.type = 'sine'
+      const time = ac.currentTime + i * 0.15
+      osc.frequency.setValueAtTime(notes[i]!, time)
+      gain.gain.setValueAtTime(0.15, time)
+      gain.gain.exponentialRampToValueAtTime(0.001, time + 0.3)
+      osc.start(time)
+      osc.stop(time + 0.3)
+    }
+  }
+
+  function playLose(): void {
+    const ac = getCtx()
+    if (!ac) return
+    const osc = ac.createOscillator()
+    const gain = ac.createGain()
+    osc.connect(gain)
+    gain.connect(ac.destination)
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(250, ac.currentTime)
+    osc.frequency.exponentialRampToValueAtTime(150, ac.currentTime + 0.4)
+    gain.gain.setValueAtTime(0.12, ac.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 0.4)
+    osc.start(ac.currentTime)
+    osc.stop(ac.currentTime + 0.4)
+  }
+
+  function playBigWin(): void {
+    const ac = getCtx()
+    if (!ac) return
+    const notes = [523, 587, 659, 784, 880, 1047]
+    for (let i = 0; i < notes.length; i++) {
+      const osc = ac.createOscillator()
+      const gain = ac.createGain()
+      osc.connect(gain)
+      gain.connect(ac.destination)
+      osc.type = 'sine'
+      const time = ac.currentTime + i * 0.1
+      osc.frequency.setValueAtTime(notes[i]!, time)
+      gain.gain.setValueAtTime(0.15, time)
+      gain.gain.exponentialRampToValueAtTime(0.001, time + 0.25)
+      osc.start(time)
+      osc.stop(time + 0.25)
+    }
+  }
+
+  const sounds: Record<SoundName, () => void> = {
+    chip: playChip,
+    spin: playSpin,
+    ballClatter: playBallClatter,
+    win: playWin,
+    lose: playLose,
+    bigWin: playBigWin,
+  }
+
+  const manager: SoundManager = {
+    get muted() {
+      return muted
+    },
+    set muted(v: boolean) {
+      muted = v
+    },
+
+    toggle(): void {
+      muted = !muted
+      localStorage.setItem('roulette-muted', String(muted))
+    },
+
+    play(name: SoundName): void {
+      if (muted) return
+      const fn = sounds[name]
+      if (fn) fn()
+    },
+  }
+
+  return manager
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,194 @@
+import { type Bet, getPocketColor } from './types'
+
+const STORAGE_KEY = 'roulette-stats'
+
+export type GameStats = {
+  totalRounds: number
+  totalWagered: number
+  totalWon: number
+  wins: number
+  losses: number
+  currentStreak: number
+  longestWinStreak: number
+  longestLoseStreak: number
+  numberBets: Record<string, number> // number -> times bet on
+}
+
+export type StatsManager = {
+  stats: GameStats
+  recordRound: (bets: Bet[], totalWin: number, result: number) => void
+  clear: () => void
+  render: () => void
+}
+
+export function createStatsManager(container: HTMLElement): StatsManager {
+  const stats: GameStats = loadStats()
+
+  function recordRound(bets: Bet[], totalWin: number, _result: number): void {
+    const totalBet = bets.reduce((sum, b) => sum + b.amount, 0)
+    stats.totalRounds++
+    stats.totalWagered += totalBet
+    stats.totalWon += totalWin
+
+    const isWin = totalWin > 0
+    if (isWin) {
+      stats.wins++
+      if (stats.currentStreak >= 0) {
+        stats.currentStreak++
+      } else {
+        stats.currentStreak = 1
+      }
+      stats.longestWinStreak = Math.max(stats.longestWinStreak, stats.currentStreak)
+    } else {
+      stats.losses++
+      if (stats.currentStreak <= 0) {
+        stats.currentStreak--
+      } else {
+        stats.currentStreak = -1
+      }
+      stats.longestLoseStreak = Math.max(
+        stats.longestLoseStreak,
+        Math.abs(stats.currentStreak),
+      )
+    }
+
+    // Track which numbers are bet on most
+    for (const bet of bets) {
+      if (bet.type === 'straight') {
+        const key = String(bet.numbers[0])
+        stats.numberBets[key] = (stats.numberBets[key] ?? 0) + 1
+      }
+    }
+
+    saveStats(stats)
+    render()
+  }
+
+  function clear(): void {
+    Object.assign(stats, defaultStats())
+    saveStats(stats)
+    render()
+  }
+
+  function getMostBetNumber(): { num: number; count: number } | null {
+    let best: { num: number; count: number } | null = null
+    for (const [key, count] of Object.entries(stats.numberBets)) {
+      if (!best || count > best.count) {
+        best = { num: Number(key), count }
+      }
+    }
+    return best
+  }
+
+  function render(): void {
+    while (container.firstChild) container.removeChild(container.firstChild)
+
+    const header = document.createElement('div')
+    header.className = 'stats-header'
+
+    const title = document.createElement('button')
+    title.className = 'stats-toggle'
+    title.textContent = 'Statistics'
+    title.setAttribute('aria-expanded', 'true')
+
+    const clearBtn = document.createElement('button')
+    clearBtn.className = 'stats-clear-btn'
+    clearBtn.textContent = 'Reset'
+    clearBtn.addEventListener('click', clear)
+
+    header.appendChild(title)
+    header.appendChild(clearBtn)
+    container.appendChild(header)
+
+    const content = document.createElement('div')
+    content.className = 'stats-content'
+
+    title.addEventListener('click', () => {
+      const expanded = content.classList.toggle('collapsed')
+      title.setAttribute('aria-expanded', String(!expanded))
+    })
+
+    const netProfit = stats.totalWon - stats.totalWagered
+    const winRate = stats.totalRounds > 0
+      ? ((stats.wins / stats.totalRounds) * 100).toFixed(1)
+      : '0.0'
+
+    const rows: { label: string; value: string; className?: string }[] = [
+      { label: 'Total Rounds', value: String(stats.totalRounds) },
+      { label: 'Total Wagered', value: `$${stats.totalWagered}` },
+      { label: 'Total Won', value: `$${stats.totalWon}` },
+      {
+        label: 'Net Profit',
+        value: `${netProfit >= 0 ? '+' : ''}$${netProfit}`,
+        className: netProfit >= 0 ? 'stat-positive' : 'stat-negative',
+      },
+      { label: 'Win Rate', value: `${winRate}%` },
+      { label: 'W/L Record', value: `${stats.wins}W / ${stats.losses}L` },
+      { label: 'Best Win Streak', value: String(stats.longestWinStreak) },
+      { label: 'Worst Lose Streak', value: String(stats.longestLoseStreak) },
+    ]
+
+    const mostBet = getMostBetNumber()
+    if (mostBet) {
+      const color = getPocketColor(mostBet.num)
+      rows.push({
+        label: 'Most Bet Number',
+        value: `${mostBet.num} (${mostBet.count}x)`,
+        className: `stat-color-${color}`,
+      })
+    }
+
+    for (const row of rows) {
+      const rowEl = document.createElement('div')
+      rowEl.className = 'stat-row'
+
+      const labelEl = document.createElement('span')
+      labelEl.className = 'stat-label'
+      labelEl.textContent = row.label
+
+      const valueEl = document.createElement('span')
+      valueEl.className = `stat-value ${row.className ?? ''}`
+      valueEl.textContent = row.value
+
+      rowEl.appendChild(labelEl)
+      rowEl.appendChild(valueEl)
+      content.appendChild(rowEl)
+    }
+
+    container.appendChild(content)
+  }
+
+  render()
+
+  return { stats, recordRound, clear, render }
+}
+
+function defaultStats(): GameStats {
+  return {
+    totalRounds: 0,
+    totalWagered: 0,
+    totalWon: 0,
+    wins: 0,
+    losses: 0,
+    currentStreak: 0,
+    longestWinStreak: 0,
+    longestLoseStreak: 0,
+    numberBets: {},
+  }
+}
+
+function loadStats(): GameStats {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return defaultStats()
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return defaultStats()
+    return parsed as GameStats
+  } catch {
+    return defaultStats()
+  }
+}
+
+function saveStats(stats: GameStats): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(stats))
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,17 @@
+const BALANCE_KEY = 'roulette-balance'
+const DEFAULT_BALANCE = 1000
+
+export function saveBalance(balance: number): void {
+  localStorage.setItem(BALANCE_KEY, String(balance))
+}
+
+export function loadBalance(): number {
+  const stored = localStorage.getItem(BALANCE_KEY)
+  if (stored === null) return DEFAULT_BALANCE
+  const parsed = Number(stored)
+  return Number.isFinite(parsed) ? parsed : DEFAULT_BALANCE
+}
+
+export function clearSavedBalance(): void {
+  localStorage.removeItem(BALANCE_KEY)
+}

--- a/src/style.css
+++ b/src/style.css
@@ -152,7 +152,7 @@ main {
   justify-content: center;
 }
 
-#spin-btn, #clear-btn {
+#spin-btn, #clear-btn, #repeat-btn, #undo-btn {
   padding: 12px 28px;
   border: none;
   border-radius: 6px;
@@ -179,18 +179,32 @@ main {
   cursor: not-allowed;
 }
 
-#clear-btn {
+#clear-btn, #repeat-btn, #undo-btn {
   background: #333;
   color: #ccc;
 }
 
-#clear-btn:hover:not(:disabled) {
+#clear-btn:hover:not(:disabled),
+#repeat-btn:hover:not(:disabled),
+#undo-btn:hover:not(:disabled) {
   background: #444;
 }
 
-#clear-btn:disabled {
+#clear-btn:disabled,
+#repeat-btn:disabled,
+#undo-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+#repeat-btn {
+  background: linear-gradient(135deg, #2a6a3a, #1a4a2a);
+  color: #aed6a0;
+}
+
+#undo-btn {
+  background: linear-gradient(135deg, #6a3a2a, #4a2a1a);
+  color: #d6a0a0;
 }
 
 .win-message, .lose-message {
@@ -208,7 +222,7 @@ main {
 }
 
 .lose-message {
-  color: #888;
+  color: #b0b0b0;
 }
 
 /* Board */
@@ -328,6 +342,177 @@ main {
 
 .hidden {
   display: none !important;
+}
+
+/* New Game button */
+#new-game-btn {
+  padding: 8px 18px;
+  border: 1px solid #d4a34a;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4a34a;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s;
+}
+
+#new-game-btn:hover {
+  background: rgba(212, 163, 74, 0.15);
+}
+
+/* Game Over Overlay */
+#game-over-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+#game-over-modal {
+  background: linear-gradient(135deg, #1a2a1a, #0a1a0a);
+  border: 2px solid #d4a34a;
+  border-radius: 12px;
+  padding: 40px 48px;
+  text-align: center;
+  max-width: 400px;
+  width: 90%;
+}
+
+#game-over-modal h2 {
+  font-size: 2rem;
+  color: #c0392b;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+#game-over-modal p {
+  color: #aaa;
+  margin-bottom: 24px;
+  font-size: 1.1rem;
+}
+
+#restart-btn {
+  padding: 14px 32px;
+  border: none;
+  border-radius: 6px;
+  background: linear-gradient(135deg, #d4a34a, #b8862a);
+  color: #1a1a2e;
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s, transform 0.1s;
+}
+
+#restart-btn:hover {
+  background: linear-gradient(135deg, #e4b35a, #c8963a);
+  transform: scale(1.02);
+}
+
+/* Focus visible outlines for keyboard navigation */
+.cell:focus-visible,
+.chip:focus-visible,
+#spin-btn:focus-visible,
+#clear-btn:focus-visible,
+#repeat-btn:focus-visible,
+#undo-btn:focus-visible,
+#new-game-btn:focus-visible,
+#restart-btn:focus-visible {
+  outline: 3px solid #d4a34a;
+  outline-offset: 2px;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .result-badge,
+  .win-message,
+  .lose-message,
+  .chip-indicator,
+  #game-over-overlay {
+    animation: none;
+  }
+
+  .chip,
+  .cell,
+  #spin-btn,
+  #clear-btn,
+  #repeat-btn,
+  #undo-btn,
+  #new-game-btn,
+  #restart-btn {
+    transition: none;
+  }
+}
+
+/* Colorblind mode */
+.colorblind-mode .cell.red {
+  background: repeating-linear-gradient(
+    45deg,
+    #c0392b,
+    #c0392b 4px,
+    #a02a1e 4px,
+    #a02a1e 8px
+  );
+}
+
+.colorblind-mode .cell.black {
+  background: radial-gradient(circle 2px, #555 1px, transparent 1px);
+  background-size: 6px 6px;
+  background-color: #1a1a2e;
+}
+
+.colorblind-mode .cell.red .cb-label,
+.colorblind-mode .cell.black .cb-label {
+  display: block;
+  font-size: 0.6rem;
+  line-height: 1;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.cb-label {
+  display: none;
+}
+
+/* Colorblind toggle button */
+#colorblind-toggle {
+  padding: 8px 14px;
+  border: 1px solid #d4a34a;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4a34a;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s;
+}
+
+#colorblind-toggle:hover {
+  background: rgba(212, 163, 74, 0.15);
+}
+
+#colorblind-toggle.active {
+  background: rgba(212, 163, 74, 0.3);
+  border-width: 2px;
 }
 
 /* Responsive */

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type GamePhase = 'betting' | 'spinning' | 'result'
 export type GameState = {
   balance: number
   bets: Bet[]
+  lastBets: Bet[]
   selectedChip: number
   phase: GamePhase
   lastResult: number | null

--- a/src/ux-styles.css
+++ b/src/ux-styles.css
@@ -1,0 +1,236 @@
+/* UX Feature Styles - Sound, History, Feedback, Stats */
+
+/* Mute toggle */
+#mute-toggle {
+  padding: 8px 14px;
+  border: 1px solid #d4a34a;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4a34a;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: background 0.2s;
+}
+
+#mute-toggle:hover {
+  background: rgba(212, 163, 74, 0.15);
+}
+
+#mute-toggle.active {
+  background: rgba(212, 163, 74, 0.3);
+  border-width: 2px;
+}
+
+/* Win/Lose cell flash feedback */
+.cell-win-flash {
+  animation: cellWinPulse 0.6s ease-in-out 3;
+}
+
+@keyframes cellWinPulse {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 16px 4px rgba(46, 204, 113, 0.8); filter: brightness(1.5); }
+}
+
+.cell-lose-flash {
+  animation: cellLoseFlash 0.4s ease-in-out 2;
+}
+
+@keyframes cellLoseFlash {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; box-shadow: 0 0 8px 2px rgba(192, 57, 43, 0.6); }
+}
+
+/* Balance animation highlight */
+.balance-up {
+  color: #2ecc71 !important;
+  text-shadow: 0 0 8px rgba(46, 204, 113, 0.5);
+}
+
+.balance-down {
+  color: #c0392b !important;
+  text-shadow: 0 0 8px rgba(192, 57, 43, 0.5);
+}
+
+/* Confetti canvas */
+.confetti-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 50;
+}
+
+/* Panels row (history + stats) */
+#panels-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+#history-container, #stats-container {
+  background: linear-gradient(135deg, #1a2a1a, #0a1a0a);
+  border: 1px solid #2a4a2a;
+  border-radius: 8px;
+  padding: 12px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.history-header, .stats-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.history-toggle, .stats-toggle {
+  background: none;
+  border: none;
+  color: #d4a34a;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 4px 0;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.history-clear-btn, .stats-clear-btn {
+  background: none;
+  border: 1px solid #555;
+  color: #888;
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.history-clear-btn:hover, .stats-clear-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #aaa;
+}
+
+.history-content.collapsed, .stats-content.collapsed {
+  display: none;
+}
+
+/* Hot/cold numbers */
+.hot-cold-bar {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid #2a4a2a;
+}
+
+.hot-numbers, .cold-numbers {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.hc-label {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  margin-right: 4px;
+}
+
+.number-badge, .result-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.number-badge.red, .result-dot.red { background: #c0392b; }
+.number-badge.black, .result-dot.black { background: #1a1a2e; border: 1px solid #444; }
+.number-badge.green, .result-dot.green { background: #27ae60; }
+
+.results-strip {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #2a4a2a;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.history-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.85rem;
+}
+
+.history-bet-info {
+  color: #aaa;
+  flex: 1;
+}
+
+.history-net-win {
+  color: #2ecc71;
+  font-weight: bold;
+}
+
+.history-net-loss {
+  color: #c0392b;
+  font-weight: bold;
+}
+
+.history-empty {
+  color: #666;
+  text-align: center;
+  padding: 16px;
+  font-style: italic;
+}
+
+/* Stats panel */
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid #1a2a1a;
+  font-size: 0.85rem;
+}
+
+.stat-label {
+  color: #aaa;
+}
+
+.stat-value {
+  font-weight: bold;
+  color: #e8e0d0;
+}
+
+.stat-positive { color: #2ecc71; }
+.stat-negative { color: #c0392b; }
+.stat-color-red { color: #c0392b; }
+.stat-color-green { color: #27ae60; }
+
+/* Responsive for panels */
+@media (max-width: 850px) {
+  #panels-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -23,6 +23,8 @@ export function createWheel(canvas: HTMLCanvasElement): {
   const ballR = outerR * 0.85
   const ballSize = 6
 
+  let rafId: number | null = null
+
   const state: WheelState = {
     angle: 0,
     ballAngle: 0,
@@ -121,6 +123,17 @@ export function createWheel(canvas: HTMLCanvasElement): {
   }
 
   function spin(targetNumber: number): Promise<number> {
+    // Cancel any in-progress animation
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+
+    // Guard against double-call while spinning
+    if (state.spinning) {
+      state.spinning = false
+    }
+
     return new Promise((resolve) => {
       state.spinning = true
       state.targetPocket = targetNumber
@@ -156,14 +169,15 @@ export function createWheel(canvas: HTMLCanvasElement): {
         draw()
 
         if (progress < 1) {
-          requestAnimationFrame(animate)
+          rafId = requestAnimationFrame(animate)
         } else {
+          rafId = null
           state.spinning = false
           resolve(targetNumber)
         }
       }
 
-      requestAnimationFrame(animate)
+      rafId = requestAnimationFrame(animate)
     })
   }
 

--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -122,6 +122,10 @@ export function createWheel(canvas: HTMLCanvasElement): {
     ctx.fill()
   }
 
+  function prefersReducedMotion(): boolean {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  }
+
   function spin(targetNumber: number): Promise<number> {
     // Cancel any in-progress animation
     if (rafId !== null) {
@@ -141,6 +145,16 @@ export function createWheel(canvas: HTMLCanvasElement): {
       const targetIndex = WHEEL_SEQUENCE.indexOf(targetNumber)
       // Target angle: the pocket should be at the top (negative Y = -PI/2)
       const targetPocketAngle = -Math.PI / 2 - targetIndex * POCKET_ARC
+
+      // Reduced motion: skip animation, jump directly to result
+      if (prefersReducedMotion()) {
+        state.angle = targetPocketAngle
+        state.ballAngle = -Math.PI / 2
+        state.spinning = false
+        draw()
+        resolve(targetNumber)
+        return
+      }
 
       // Wheel spins multiple full rotations + lands on target
       const totalWheelSpin = Math.PI * 2 * (5 + Math.random() * 3)


### PR DESCRIPTION
## Summary

- **Sound effects** (#12): Web Audio API procedural sounds (chip click, spin sweep, ball clatter, win chime, lose thud, big win arpeggio). Mute toggle with localStorage persistence. Respects `prefers-reduced-motion`.
- **Bet history panel** (#13): Collapsible panel showing last 20 spins with colored result dots, bet totals, and net gain/loss. Persisted to localStorage.
- **Win/loss feedback** (#25): Winning number cell flashes green, losing straight-bet cells flash red. Balance counter animates with easing. Confetti particle effect for 35:1 straight bet wins.
- **Statistics panel** (#28): Tracks total rounds, wagered, won, net profit, win rate, W/L record, win/lose streaks, most bet number. Collapsible with localStorage persistence.

## New Files

- `src/sound.ts` - Web Audio API sound manager
- `src/history.ts` - Bet history manager with DOM rendering
- `src/feedback.ts` - Visual feedback (cell highlights, balance animation, confetti)
- `src/stats.ts` - Statistics tracking and display
- `src/ux-styles.css` - Styles for all UX feature panels and animations

## Modified Files

- `src/main.ts` - Integrated all 4 UX managers into game flow
- `index.html` - Mute toggle button, history/stats panel containers

Closes #12, #13, #25, #28

## Test plan

- [ ] Place bets and verify chip click sound plays
- [ ] Spin and verify spin sound, ball clatter, win/lose sounds
- [ ] Toggle mute button - verify sounds stop, preference persists on reload
- [ ] Verify history panel populates after each spin
- [ ] Verify stats panel updates (rounds, wagered, won, streaks)
- [ ] Win a straight bet - verify confetti effect and big win sound
- [ ] Verify balance counter animates smoothly on win/loss
- [ ] Verify winning cell flashes green, losing bet cells flash red
- [ ] Clear history/stats and verify localStorage is cleared
- [ ] New Game resets history and stats